### PR TITLE
chore(bower): remove moot `version` property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     "dist/js/ozpIwc-metrics-angular.js",
     "dist/js/ozpIwc-metrics-angular.min.js"
   ],
-  "version": "0.0.1",
   "homepage": "https://github.com/ozone-development/ozp-iwc-angular",
   "authors": [
     "Ozone Developers"


### PR DESCRIPTION
Per the [Bower spec](https://github.com/bower/bower.json-spec#version) the version property is not used for anything.  

One of the maintainers also says that they are [not likely to use it in the future](http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property).